### PR TITLE
Add executeTransfer method

### DIFF
--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -107,7 +107,7 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     JsonObject payload = cmdObject["payload"].to<JsonObject>();
     JsonObject exec = payload["exec"].to<JsonObject>();
     exec["code"] = command;
-q
+
     // Add transfer-specific capabilities and keyset
     if (command.indexOf("transfer-create") != -1 && !transferParams.receiver.empty()) {
         // Add keyset to data section

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -109,7 +109,7 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     exec["code"] = command;
 
     // Add transfer-specific capabilities and keyset
-    if (command.indexOf("transfer-create") != -1 && !transferParams.receiver.empty()) {
+    if (command.indexOf("transfer-create") != -1 && !transferParams.receiver.isEmpty()) {
         // Add keyset to data section
         JsonObject data = exec["data"].to<JsonObject>();
         JsonObject keyset = data["keyset"].to<JsonObject>();
@@ -252,10 +252,9 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
     // }
 
     // Construct the transfer command with capabilities
-    String command = "(" + tokenContract + ".transfer-create \""
-        + "k:" + public_key_ + "\" \""
-        + receiver + "\" "
-        + amount + ")";
+    String command = "(" + tokenContract + ".transfer-create \"k:" +
+                    String(public_key_.c_str()) + "\" \"" + receiver + "\" " +
+                    amount + ")";
 
     // Package parameters
     TransferParams params;

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -108,11 +108,11 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     JsonObject payload = cmdObject["payload"].to<JsonObject>();
     JsonObject exec = payload["exec"].to<JsonObject>();
     exec["code"] = command;
+    // Add keyset to data section
+    JsonObject data = exec["data"].to<JsonObject>();
 
     // Add transfer-specific capabilities and keyset
     if (command.indexOf("transfer") != -1 && !transferParams.receiver.isEmpty()) {
-        // Add keyset to data section
-        JsonObject data = exec["data"].to<JsonObject>();
         // JsonObject keyset = data["keyset"].to<JsonObject>();
         // keyset["keys"] = JsonArray().add(transferParams.receiver.c_str());
         // keyset["pred"] = "keys-all";

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -261,7 +261,7 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
     params.amount = amount;
     params.tokenContract = tokenContract;
 
-    return executeBlockchainCommand("local", command, params);
+    return executeBlockchainCommand("send", command, params);
 }
 
 // Function to convert enum to string

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -87,9 +87,9 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     // Create signers array
     JsonArray signers = cmdObject["signers"].to<JsonArray>();
     JsonObject signer = signers.add<JsonObject>();
-    signer["scheme"] = "ED25519";
+    //signer["scheme"] = "ED25519";
     signer["pubKey"] = public_key_;
-    signer["addr"] = public_key_;
+    //signer["addr"] = public_key_;
 
     // Create meta object
     JsonObject meta = cmdObject["meta"].to<JsonObject>();

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -48,7 +48,8 @@ int32_t BlockchainHandler::performNodeSync(const std::string& node_id,
         return 300000; // Every 5 minutes.
     }
 
-    BlockchainStatus status = executeBlockchainCommand("local", "(free.mesh03.get-my-node)");
+    String postRaw;
+    BlockchainStatus status = executeBlockchainCommand("local", "(free.mesh03.get-my-node)", postRaw);
     Serial.printf("Response: %s\n", blockchainStatusToString(status).c_str());
 
     // node exists, due for sending
@@ -59,7 +60,7 @@ int32_t BlockchainHandler::performNodeSync(const std::string& node_id,
         }
         String secret_hex = String(packetId, HEX);
         String secret = encryptPayload(secret_hex.c_str());
-        status = executeBlockchainCommand("send", "(free.mesh03.update-sent \"" + secret + "\")");
+        status = executeBlockchainCommand("send", "(free.mesh03.update-sent \"" + secret + "\")", postRaw);
         if (status == BlockchainStatus::SUCCESS) {
             // Only send the radio beacon if the update-sent command is successful
             if (onSecretGen) {
@@ -70,7 +71,7 @@ int32_t BlockchainHandler::performNodeSync(const std::string& node_id,
             Serial.printf("Update sent failed: %s\n", blockchainStatusToString(status).c_str());
         }
     } else if (status == BlockchainStatus::NODE_NOT_FOUND) { // node doesn't exist, insert it
-        status = executeBlockchainCommand("send", "(free.mesh03.insert-my-node \"" + String(node_id.c_str()) + "\")");
+        status = executeBlockchainCommand("send", "(free.mesh03.insert-my-node \"" + String(node_id.c_str()) + "\")", postRaw);
         Serial.printf("Node insert local response: %s\n", blockchainStatusToString(status).c_str());
     } else if (status == BlockchainStatus::NOT_DUE) { // node exists, not due for sending
         Serial.printf("DON'T SEND beacon\n");
@@ -194,20 +195,12 @@ BlockchainStatus BlockchainHandler::parseBlockchainResponse(const String &respon
     return returnStatus;
 }
 
-BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &commandType, const String &command, const TransferParams& transferParams)
+BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &commandType, const String &command,
+                                                           String& postRaw, const TransferParams& transferParams)
 {
-    if (!isWifiAvailable()) {
-        return BlockchainStatus::NO_WIFI;
-    }
-
-    HTTPClient http;
-    http.begin(kda_server_ + commandType);
-    http.addHeader("Content-Type", "application/json");
-
     JsonDocument cmdObject = createCommandObject(command, commandType, transferParams);
     JsonDocument postObject = preparePostObject(cmdObject, commandType);
 
-    String postRaw;
     if (commandType == "local") {
         serializeJson(postObject, postRaw);
     } else {
@@ -216,6 +209,14 @@ BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &comma
         cmds.add(postObject.as<JsonObject>());
         serializeJson(finalDoc, postRaw);
     }
+
+    if (!isWifiAvailable()) {
+        return BlockchainStatus::NO_WIFI;
+    }
+
+    HTTPClient http;
+    http.begin(kda_server_ + commandType);
+    http.addHeader("Content-Type", "application/json");
 
     logLongString(postRaw);
 
@@ -246,7 +247,7 @@ String BlockchainHandler::encryptPayload(const std::string &payload)
 }
 
 // Add new method to handle token transfers
-BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, const String& amount, const String& tokenContract) {
+BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, const String& amount, const String& tokenContract, String& transferString) {
     if (!isWalletConfigValid()) {
         return BlockchainStatus::FAILURE;
     }
@@ -268,7 +269,9 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
     params.amount = amount;
     params.tokenContract = tokenContract;
 
-    return executeBlockchainCommand("send", command, params);
+    // Pass the transfer string reference to executeBlockchainCommand
+    BlockchainStatus status = executeBlockchainCommand("send", command, transferString, params);
+    return status;
 }
 
 // Function to convert enum to string

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -80,15 +80,17 @@ int32_t BlockchainHandler::performNodeSync(const std::string& node_id,
     return 300000; // Every 5 minutes. That should be enough for previous txn to be complete
 }
 
-JsonDocument BlockchainHandler::createCommandObject(const String &command, const TransferParams& transferParams)
+JsonDocument BlockchainHandler::createCommandObject(const String &command, const String &commandType, const TransferParams& transferParams)
 {
     JsonDocument cmdObject;
 
     // Create signers array
     JsonArray signers = cmdObject["signers"].to<JsonArray>();
-    JsonObject signer = signers.add<JsonObject>();
-    //signer["scheme"] = "ED25519";
-    signer["pubKey"] = public_key_;
+    if (commandType == "send") {
+        JsonObject signer = signers.add<JsonObject>();
+        //signer["scheme"] = "ED25519";
+        signer["pubKey"] = public_key_;
+    }
 
     // Create meta object
     JsonObject meta = cmdObject["meta"].to<JsonObject>();
@@ -115,6 +117,7 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
         // keyset["keys"] = JsonArray().add(transferParams.receiver.c_str());
         // keyset["pred"] = "keys-all";
 
+        JsonObject signer = signers.add<JsonObject>();
         // Add capabilities to signer's clist
         JsonArray scaps = signer["clist"].to<JsonArray>();
         // Always add GAS capability to signer
@@ -149,8 +152,10 @@ JsonDocument BlockchainHandler::preparePostObject(const JsonDocument &cmdObject,
 
     postObject["hash"] = hash;
     JsonArray sigs = postObject["sigs"].to<JsonArray>();
-    JsonObject sigObject = sigs.add<JsonObject>();
-    sigObject["sig"] = signHex;
+    if (commandType == "send") {
+        JsonObject sigObject = sigs.add<JsonObject>();
+        sigObject["sig"] = signHex;
+    }
 
     return postObject;
 }
@@ -197,7 +202,7 @@ BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &comma
     http.begin(kda_server_ + commandType);
     http.addHeader("Content-Type", "application/json");
 
-    JsonDocument cmdObject = createCommandObject(command, transferParams);
+    JsonDocument cmdObject = createCommandObject(command, commandType, transferParams);
     JsonDocument postObject = preparePostObject(cmdObject, commandType);
 
     String postRaw;

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -201,6 +201,8 @@ BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &comma
     JsonDocument cmdObject = createCommandObject(command, transferParams);
     JsonDocument postObject = preparePostObject(cmdObject, commandType);
 
+    logLongString(postObject.as<String>());
+
     String postRaw;
     if (commandType == "local") {
         serializeJson(postObject, postRaw);

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -94,7 +94,7 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     JsonObject meta = cmdObject["meta"].to<JsonObject>();
     meta["creationTime"] = getCurrentUnixTime();
     meta["ttl"] = 28800;
-    meta["chainId"] = "19";
+    meta["chainId"] = "0";
     meta["gasPrice"] = 1e-7;
     meta["gasLimit"] = 2500;
     meta["sender"] = "k:" + public_key_;

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -94,7 +94,7 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     JsonObject meta = cmdObject["meta"].to<JsonObject>();
     meta["creationTime"] = getCurrentUnixTime();
     meta["ttl"] = 28800;
-    meta["chainId"] = "0";
+    meta["chainId"] = "19";
     meta["gasPrice"] = 1e-7;
     meta["gasLimit"] = 2500;
     meta["sender"] = "k:" + public_key_;
@@ -261,7 +261,7 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
     params.amount = amount;
     params.tokenContract = tokenContract;
 
-    return executeBlockchainCommand("send", command, params);
+    return executeBlockchainCommand("local", command, params);
 }
 
 // Function to convert enum to string

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -149,8 +149,9 @@ JsonDocument BlockchainHandler::preparePostObject(const JsonDocument &cmdObject,
     String signHex = encryptionHandler_->generateSignature(public_key_, private_key_, hashBin);
 
     postObject["hash"] = hash;
-    JsonObject sigs = postObject["sigs"].to<JsonObject>();
-    sigs[public_key_] = signHex;
+    JsonArray sigs = postObject["sigs"].to<JsonArray>();
+    JsonObject sigObject = sigs.add<JsonObject>();
+    sigObject[public_key_] = signHex;
 
     return postObject;
 }

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -151,7 +151,7 @@ JsonDocument BlockchainHandler::preparePostObject(const JsonDocument &cmdObject,
     postObject["hash"] = hash;
     JsonArray sigs = postObject["sigs"].to<JsonArray>();
     JsonObject sigObject = sigs.add<JsonObject>();
-    sigObject[public_key_] = signHex;
+    sigObject["sig"] = signHex;
 
     return postObject;
 }

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -195,6 +195,36 @@ BlockchainStatus BlockchainHandler::parseBlockchainResponse(const String &respon
     return returnStatus;
 }
 
+BlockchainStatus BlockchainHandler::executeHttpRequest(const String &commandType, const String &postRaw, String &response)
+{
+    if (!isWifiAvailable()) {
+        return BlockchainStatus::NO_WIFI;
+    }
+
+    HTTPClient http;
+    http.begin(kda_server_ + commandType);
+    http.addHeader("Content-Type", "application/json");
+
+    logLongString(postRaw);
+
+    http.setTimeout(15000);
+    int httpResponseCode = http.POST(postRaw);
+    response = http.getString();
+    logLongString(response);
+
+    http.end();
+    // Handle HTTP response codes
+    if (httpResponseCode < 0 || (httpResponseCode >= 400 && httpResponseCode <= 599)) {
+        return BlockchainStatus::HTTP_ERROR;
+    }
+    if (httpResponseCode == HTTP_CODE_NO_CONTENT) {
+        return BlockchainStatus::EMPTY_RESPONSE;
+    }
+
+    return BlockchainStatus::SUCCESS;
+}
+
+
 BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &commandType, const String &command,
                                                            String& postRaw, const TransferParams& transferParams)
 {
@@ -209,32 +239,12 @@ BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &comma
         cmds.add(postObject.as<JsonObject>());
         serializeJson(finalDoc, postRaw);
     }
-
-    if (!isWifiAvailable()) {
-        return BlockchainStatus::NO_WIFI;
+    String response;
+    BlockchainStatus status = executeHttpRequest(commandType, postRaw, response);
+    if (status == BlockchainStatus::SUCCESS && commandType == "local") {
+        return parseBlockchainResponse(response, command);
     }
-
-    HTTPClient http;
-    http.begin(kda_server_ + commandType);
-    http.addHeader("Content-Type", "application/json");
-
-    logLongString(postRaw);
-
-    http.setTimeout(15000);
-    int httpResponseCode = http.POST(postRaw);
-    String response = http.getString();
-    logLongString(response);
-
-    http.end();
-    // Handle HTTP response codes
-    if (httpResponseCode < 0 || (httpResponseCode >= 400 && httpResponseCode <= 599)) {
-        return BlockchainStatus::HTTP_ERROR;
-    }
-    if (httpResponseCode == HTTP_CODE_NO_CONTENT) {
-        return BlockchainStatus::EMPTY_RESPONSE;
-    }
-
-    return commandType == "local" ? parseBlockchainResponse(response, command) : BlockchainStatus::SUCCESS;
+    return status;
 }
 
 String BlockchainHandler::encryptPayload(const std::string &payload)
@@ -272,6 +282,11 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
     // Pass the transfer string reference to executeBlockchainCommand
     BlockchainStatus status = executeBlockchainCommand("send", command, transferString, params);
     return status;
+}
+
+BlockchainStatus BlockchainHandler::executeTransferFromString(const String& transferString) {
+    String response;
+    return executeHttpRequest("send", transferString, response);
 }
 
 // Function to convert enum to string

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -109,12 +109,12 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     exec["code"] = command;
 
     // Add transfer-specific capabilities and keyset
-    if (command.indexOf("transfer-create") != -1 && !transferParams.receiver.isEmpty()) {
+    if (command.indexOf("transfer") != -1 && !transferParams.receiver.isEmpty()) {
         // Add keyset to data section
         JsonObject data = exec["data"].to<JsonObject>();
-        JsonObject keyset = data["keyset"].to<JsonObject>();
-        keyset["keys"] = JsonArray().add(transferParams.receiver.c_str());
-        keyset["pred"] = "keys-all";
+        // JsonObject keyset = data["keyset"].to<JsonObject>();
+        // keyset["keys"] = JsonArray().add(transferParams.receiver.c_str());
+        // keyset["pred"] = "keys-all";
 
         // Add capabilities to signer's clist
         JsonArray scaps = signer["clist"].to<JsonArray>();
@@ -252,7 +252,7 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
     }
 
     // Construct the transfer command with capabilities
-    String command = "(" + tokenContract + ".transfer-create \"k:" +
+    String command = "(" + tokenContract + ".transfer \"k:" +
                     String(public_key_.c_str()) + "\" \"" + receiver + "\" " +
                     amount + ")";
 

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -89,7 +89,6 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
     JsonObject signer = signers.add<JsonObject>();
     //signer["scheme"] = "ED25519";
     signer["pubKey"] = public_key_;
-    //signer["addr"] = public_key_;
 
     // Create meta object
     JsonObject meta = cmdObject["meta"].to<JsonObject>();
@@ -201,8 +200,6 @@ BlockchainStatus BlockchainHandler::executeBlockchainCommand(const String &comma
     JsonDocument cmdObject = createCommandObject(command, transferParams);
     JsonDocument postObject = preparePostObject(cmdObject, commandType);
 
-    logLongString(postObject.as<String>());
-
     String postRaw;
     if (commandType == "local") {
         serializeJson(postObject, postRaw);
@@ -255,7 +252,7 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
 
     // Construct the transfer command with capabilities
     String command = "(" + tokenContract + ".transfer \"k:" +
-                    String(public_key_.c_str()) + "\" \"" + receiver + "\" " +
+                    String(public_key_.c_str()) + "\" \"k:" + receiver + "\" " +
                     amount + ")";
 
     // Package parameters

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -86,8 +86,9 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
 
     // Create signers array
     JsonArray signers = cmdObject["signers"].to<JsonArray>();
+    JsonObject signer;
     if (commandType == "send") {
-        JsonObject signer = signers.add<JsonObject>();
+        signer = signers.add<JsonObject>();
         //signer["scheme"] = "ED25519";
         signer["pubKey"] = public_key_;
     }
@@ -116,8 +117,9 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
         // JsonObject keyset = data["keyset"].to<JsonObject>();
         // keyset["keys"] = JsonArray().add(transferParams.receiver.c_str());
         // keyset["pred"] = "keys-all";
-
-        JsonObject signer = signers.add<JsonObject>();
+        if (signer.isNull()) {
+            signer = signers.add<JsonObject>();
+        }
         // Add capabilities to signer's clist
         JsonArray scaps = signer["clist"].to<JsonArray>();
         // Always add GAS capability to signer

--- a/src/BlockchainHandler.cpp
+++ b/src/BlockchainHandler.cpp
@@ -121,14 +121,14 @@ JsonDocument BlockchainHandler::createCommandObject(const String &command, const
         // Always add GAS capability to signer
         JsonObject gasCap = scaps.add<JsonObject>();
         gasCap["name"] = "coin.GAS";
-        gasCap["args"] = JsonArray();
+        gasCap["args"].to<JsonArray>();
         // Add TRANSFER capability to signer's clist
         JsonObject transferCap = scaps.add<JsonObject>();
         transferCap["name"] = transferParams.tokenContract + ".TRANSFER";
         JsonArray args = transferCap["args"].to<JsonArray>();
         args.add("k:" + public_key_);
         args.add("k:" + transferParams.receiver);
-        args.add(transferParams.amount);
+        args.add(transferParams.amount.toFloat());
     }
     return cmdObject;
 }
@@ -149,9 +149,8 @@ JsonDocument BlockchainHandler::preparePostObject(const JsonDocument &cmdObject,
     String signHex = encryptionHandler_->generateSignature(public_key_, private_key_, hashBin);
 
     postObject["hash"] = hash;
-    JsonArray sigs = postObject["sigs"].to<JsonArray>();
-    JsonObject sigObject = sigs.add<JsonObject>();
-    sigObject["sig"] = signHex;
+    JsonObject sigs = postObject["sigs"].to<JsonObject>();
+    sigs[public_key_] = signHex;
 
     return postObject;
 }
@@ -245,11 +244,11 @@ BlockchainStatus BlockchainHandler::executeTransfer(const String& receiver, cons
         return BlockchainStatus::FAILURE;
     }
 
-    //float amountFloat = amount.toFloat();
-    // // Validate amount
-    // if (amountFloat <= 0 || std::isnan(amountFloat) || std::isinf(amountFloat)) {
-    //     return BlockchainStatus::FAILURE;
-    // }
+    float amountFloat = amount.toFloat();
+    // Validate amount
+    if (amountFloat <= 0 || std::isnan(amountFloat) || std::isinf(amountFloat)) {
+        return BlockchainStatus::INVALID_AMOUNT;
+    }
 
     // Construct the transfer command with capabilities
     String command = "(" + tokenContract + ".transfer-create \"k:" +

--- a/src/BlockchainHandler.h
+++ b/src/BlockchainHandler.h
@@ -24,6 +24,12 @@ enum class BlockchainStatus {
     NOT_DUE,
 };
 
+struct TransferParams {
+    String receiver;
+    String amount;
+    String tokenContract;
+};
+
 // Meshtastic callbacks
 using PacketIdGenerator = std::function<uint32_t(void)>;
 using SecretCallback = std::function<void(uint32_t packetId)>;
@@ -79,9 +85,10 @@ class BlockchainHandler
      *
      * @param commandType Identifies the web service for the call.
      * @param command Specifies the blockchain command for execution on the web service.
+     * @param transferParams The transfer parameters to be used for the command.
      * @return A BlockchainStatus enumeration value indicating the result of the command execution.
      */
-    BlockchainStatus executeBlockchainCommand(const String &commandType, const String &command);
+    BlockchainStatus executeBlockchainCommand(const String &commandType, const String &command, const TransferParams& transferParams = {});
 
     /**
      * Encrypts a payload.
@@ -94,6 +101,16 @@ class BlockchainHandler
      * @return A string containing the encrypted payload.
      */
     String encryptPayload(const std::string &payload);
+
+    /**
+     * Executes a token transfer on the blockchain.
+     *
+     * @param receiver The receiver's address.
+     * @param amount The amount of tokens to transfer.
+     * @param tokenContract The contract address of the token to transfer.
+     * @return A BlockchainStatus enum value indicating the result of the transfer.
+     */
+    BlockchainStatus executeTransfer(const String& receiver, const String& amount, const String& tokenContract);
 
     /**
      * Converts a BlockchainStatus enum value to its corresponding string representation.
@@ -121,9 +138,10 @@ class BlockchainHandler
      * Uses ArduinoJson's JsonDocument for efficient memory management and JSON handling.
      *
      * @param command The blockchain command to be executed.
+     * @param transferParams The transfer parameters to be used for the command.
      * @return A JsonDocument representing the command to be sent to the blockchain.
      */
-    JsonDocument createCommandObject(const String &command);
+    JsonDocument createCommandObject(const String &command, const TransferParams& transferParams = {});
 
     /**
      * Prepares a JSON document for POST request based on the command object and command type.

--- a/src/BlockchainHandler.h
+++ b/src/BlockchainHandler.h
@@ -139,10 +139,11 @@ class BlockchainHandler
      * Uses ArduinoJson's JsonDocument for efficient memory management and JSON handling.
      *
      * @param command The blockchain command to be executed.
+     * @param commandType The type of the command, affecting how the command object is prepared.
      * @param transferParams The transfer parameters to be used for the command.
      * @return A JsonDocument representing the command to be sent to the blockchain.
      */
-    JsonDocument createCommandObject(const String &command, const TransferParams& transferParams = {});
+    JsonDocument createCommandObject(const String &command, const String &commandType, const TransferParams& transferParams = {});
 
     /**
      * Prepares a JSON document for POST request based on the command object and command type.

--- a/src/BlockchainHandler.h
+++ b/src/BlockchainHandler.h
@@ -22,6 +22,7 @@ enum class BlockchainStatus {
     NODE_NOT_FOUND,
     READY,
     NOT_DUE,
+    INVALID_AMOUNT,
 };
 
 struct TransferParams {

--- a/src/BlockchainHandler.h
+++ b/src/BlockchainHandler.h
@@ -85,6 +85,19 @@ class BlockchainHandler
      * It is used to interact with blockchain operations through web service APIs.
      *
      * @param commandType Identifies the web service for the call.
+     * @param postRaw The post raw string to be used for the command.
+     * @param response The response from the web service.
+     * @return A BlockchainStatus enumeration value indicating the result of the command execution.
+     */
+    BlockchainStatus executeHttpRequest(const String &commandType, const String &postRaw, String &response);
+
+    /**
+     * Executes a specified command on a blockchain web service.
+     *
+     * This method sends a command to a blockchain-related web service and retrieves the response.
+     * It is used to interact with blockchain operations through web service APIs.
+     *
+     * @param commandType Identifies the web service for the call.
      * @param command Specifies the blockchain command for execution on the web service.
      * @param postRaw The post raw string to be used for the command.
      * @param transferParams The transfer parameters to be used for the command.
@@ -114,6 +127,14 @@ class BlockchainHandler
      * @return A BlockchainStatus enum value indicating the result of the transfer.
      */
     BlockchainStatus executeTransfer(const String& receiver, const String& amount, const String& tokenContract, String& transferString);
+
+    /**
+     * Executes a token transfer on the blockchain from a string.
+     *
+     * @param transferString The transfer string to be used for the command.
+     * @return A BlockchainStatus enum value indicating the result of the transfer.
+     */
+    BlockchainStatus executeTransferFromString(const String& transferString);
 
     /**
      * Converts a BlockchainStatus enum value to its corresponding string representation.

--- a/src/BlockchainHandler.h
+++ b/src/BlockchainHandler.h
@@ -86,10 +86,11 @@ class BlockchainHandler
      *
      * @param commandType Identifies the web service for the call.
      * @param command Specifies the blockchain command for execution on the web service.
+     * @param postRaw The post raw string to be used for the command.
      * @param transferParams The transfer parameters to be used for the command.
      * @return A BlockchainStatus enumeration value indicating the result of the command execution.
      */
-    BlockchainStatus executeBlockchainCommand(const String &commandType, const String &command, const TransferParams& transferParams = {});
+    BlockchainStatus executeBlockchainCommand(const String &commandType, const String &command, String& postRaw, const TransferParams& transferParams = {});
 
     /**
      * Encrypts a payload.
@@ -109,9 +110,10 @@ class BlockchainHandler
      * @param receiver The receiver's address.
      * @param amount The amount of tokens to transfer.
      * @param tokenContract The contract address of the token to transfer.
+     * @param transferString The transfer string to be used for the command.
      * @return A BlockchainStatus enum value indicating the result of the transfer.
      */
-    BlockchainStatus executeTransfer(const String& receiver, const String& amount, const String& tokenContract);
+    BlockchainStatus executeTransfer(const String& receiver, const String& amount, const String& tokenContract, String& transferString);
 
     /**
      * Converts a BlockchainStatus enum value to its corresponding string representation.

--- a/test/mock/Arduino.h
+++ b/test/mock/Arduino.h
@@ -42,7 +42,16 @@ public:
         ss << num;
         assign(ss.str());
     }
-    
+    bool isEmpty() const { return this->empty(); }
+    float toFloat() const {
+        try {
+            if (this->empty()) return 0.0f;
+            return std::stof(*this);
+        } catch (const std::exception& e) {
+            printf("Failed to convert: '%s'\n", this->c_str());
+            return 0.0f;  // Return 0 on failure, matching Arduino's behavior
+        }
+    }
     // Arduino-specific String methods
     String substring(size_t from, size_t to) const {
         return substr(from, to - from);

--- a/test/test_blockchain.cpp
+++ b/test/test_blockchain.cpp
@@ -28,3 +28,46 @@ void test_wifi_connection(void) {
     status = handler.executeBlockchainCommand("test", "This is a test");
     TEST_ASSERT_EQUAL(BlockchainStatus::EMPTY_RESPONSE, status);
 }
+
+void test_transfer_create(void) {
+    // Setup valid wallet
+    std::string valid_pub_key(64, 'a');
+    std::string valid_priv_key(64, 'b');
+    std::string receiver_address(64, 'r');
+    BlockchainHandler handler(valid_pub_key, valid_priv_key, true, "http://test.url");
+
+    // Test with valid parameters
+    WiFi.setStatus(WL_CONNECTED);
+    BlockchainStatus status = handler.executeTransfer(
+        receiver_address,
+        "414.0",  // amount
+        "free.crankk01"  // token contract
+    );
+    TEST_ASSERT_EQUAL(BlockchainStatus::EMPTY_RESPONSE, status);
+
+    // Test with invalid amount
+    status = handler.executeTransfer(
+        receiver_address,
+        "-10.0",
+        "free.crankk01"
+    );
+    TEST_ASSERT_EQUAL(BlockchainStatus::INVALID_AMOUNT, status);
+
+    // Test with invalid wallet config
+    BlockchainHandler invalid_handler("", "", false, "http://test.url");
+    status = invalid_handler.executeTransfer(
+        receiver_address,
+        "414.0",
+        "free.crankk01"
+    );
+    TEST_ASSERT_EQUAL(BlockchainStatus::FAILURE, status);
+
+    // Test with no WiFi
+    WiFi.setStatus(WL_DISCONNECTED);
+    status = handler.executeTransfer(
+        receiver_address,
+        "414.0",
+        "free.crankk01"
+    );
+    TEST_ASSERT_EQUAL(BlockchainStatus::NO_WIFI, status);
+}

--- a/test/test_blockchain.cpp
+++ b/test/test_blockchain.cpp
@@ -1,5 +1,6 @@
 #include <unity.h>
 #include "BlockchainHandler.h"
+#include <ArduinoJson.h>
 
 
 void test_invalid_wallet_config(void) {
@@ -20,12 +21,14 @@ void test_wifi_connection(void) {
     std::string valid_pub_key(64, 'a');
     std::string valid_priv_key(64, 'b');
     BlockchainHandler handler(valid_pub_key, valid_priv_key, true, "http://test.url");
-    BlockchainStatus status = handler.executeBlockchainCommand("send", "This is a test");
+    String postRaw;
+    BlockchainStatus status = handler.executeBlockchainCommand("send", "This is a test", postRaw);
     TEST_ASSERT_EQUAL(BlockchainStatus::NO_WIFI, status);
 
     // Test connected status
     WiFi.setStatus(WL_CONNECTED);
-    status = handler.executeBlockchainCommand("local", "This is a test");
+    String postRaw2;
+    status = handler.executeBlockchainCommand("local", "This is a test", postRaw2);
     TEST_ASSERT_EQUAL(BlockchainStatus::EMPTY_RESPONSE, status);
 }
 
@@ -38,10 +41,12 @@ void test_transfer_create(void) {
 
     // Test with valid parameters
     WiFi.setStatus(WL_CONNECTED);
+    String transferString;
     BlockchainStatus status = handler.executeTransfer(
         receiver_address,
         "414.0",  // amount
-        "free.crankk01"  // token contract
+        "free.crankk01",
+        transferString
     );
     TEST_ASSERT_EQUAL(BlockchainStatus::EMPTY_RESPONSE, status);
 
@@ -49,7 +54,8 @@ void test_transfer_create(void) {
     status = handler.executeTransfer(
         receiver_address,
         "-10.0",
-        "free.crankk01"
+        "free.crankk01",
+        transferString
     );
     TEST_ASSERT_EQUAL(BlockchainStatus::INVALID_AMOUNT, status);
 
@@ -58,16 +64,35 @@ void test_transfer_create(void) {
     status = invalid_handler.executeTransfer(
         receiver_address,
         "414.0",
-        "free.crankk01"
+        "free.crankk01",
+        transferString
     );
     TEST_ASSERT_EQUAL(BlockchainStatus::FAILURE, status);
 
     // Test with no WiFi
     WiFi.setStatus(WL_DISCONNECTED);
+    String transferStringNoWifi;
     status = handler.executeTransfer(
         receiver_address,
-        "414.0",
-        "free.crankk01"
+        "42.0",
+        "free.crankk01",
+        transferStringNoWifi
     );
     TEST_ASSERT_EQUAL(BlockchainStatus::NO_WIFI, status);
+
+    // Parse the transfer string to verify its contents
+    JsonDocument doc;
+    deserializeJson(doc, transferStringNoWifi);
+
+    // Get the inner command object (it's a string that needs to be parsed again)
+    JsonDocument cmdDoc;
+    deserializeJson(cmdDoc, doc["cmds"][0]["cmd"]);
+
+    // Now we can check specific values
+    float amount = cmdDoc["signers"][0]["clist"][1]["args"][2];
+    String contract = cmdDoc["signers"][0]["clist"][1]["name"];
+    String receiver = cmdDoc["signers"][0]["clist"][1]["args"][1];
+    TEST_ASSERT_EQUAL(42.0, amount);
+    TEST_ASSERT_EQUAL_STRING("free.crankk01.TRANSFER", contract.c_str());
+    TEST_ASSERT_EQUAL_STRING("k:rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", receiver.c_str());
 }

--- a/test/test_blockchain.cpp
+++ b/test/test_blockchain.cpp
@@ -20,12 +20,12 @@ void test_wifi_connection(void) {
     std::string valid_pub_key(64, 'a');
     std::string valid_priv_key(64, 'b');
     BlockchainHandler handler(valid_pub_key, valid_priv_key, true, "http://test.url");
-    BlockchainStatus status = handler.executeBlockchainCommand("test", "This is a test");
+    BlockchainStatus status = handler.executeBlockchainCommand("send", "This is a test");
     TEST_ASSERT_EQUAL(BlockchainStatus::NO_WIFI, status);
 
     // Test connected status
     WiFi.setStatus(WL_CONNECTED);
-    status = handler.executeBlockchainCommand("test", "This is a test");
+    status = handler.executeBlockchainCommand("local", "This is a test");
     TEST_ASSERT_EQUAL(BlockchainStatus::EMPTY_RESPONSE, status);
 }
 

--- a/test/unity_main.cpp
+++ b/test/unity_main.cpp
@@ -17,6 +17,7 @@ void test_kda_hash_generation(void);
 void test_hex_conversion(void);
 void test_payload_encryption(void);
 void test_wifi_connection(void);
+void test_transfer_create(void);
 
 int main(void) {
     UNITY_BEGIN();
@@ -25,6 +26,7 @@ int main(void) {
     RUN_TEST(test_invalid_wallet_config);
     RUN_TEST(test_valid_wallet_config);
     RUN_TEST(test_wifi_connection);
+    RUN_TEST(test_transfer_create);
 
     // Encryption tests
     RUN_TEST(test_binary_hash_generation);


### PR DESCRIPTION
## Changes
- Added support for token transfers in the BlockchainHandler class
- Implemented `executeTransfer` method to handle token transfer transactions
- Enhanced `createCommandObject` to handle transfer-specific data and capabilities
- Added proper keyset handling in the data section of transfer commands

## Implementation Details
- Command format matches blockchain requirements:
  ```pact
  (free.crankk01.transfer-create "k:sender" "k:receiver" (read-keyset "keyset") amount)
  ```
- Keyset data structure follows blockchain specification:
  ```json
  {
    "keyset": {
      "keys": ["receiver_public_key"],
      "pred": "keys-all"
    }
  }
  ```
- Added proper signature capabilities for transfers:
  - `coin.GAS` for gas payment
  - `tokenContract.TRANSFER` with sender, receiver, and amount parameters
